### PR TITLE
OCP CI preparations

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,7 +2,9 @@
 !.git
 !cloud-controller-manager
 !Makefile
-!hack/pkg-config.sh
+!openshift.mk
+!openshift-hack
+!hack
 !vendor
 !cmd
 !pkg

--- a/Makefile
+++ b/Makefile
@@ -207,3 +207,9 @@ deploy: image push
 .PHONY: release-staging
 release-staging:
 	ENABLE_GIT_COMMANDS=false IMAGE_REGISTRY=$(STAGING_REGISTRY) $(MAKE) build-images push-images
+
+## --------------------------------------
+## Openshift specific include
+## --------------------------------------
+
+include openshift.mk

--- a/openshift-hack/build-go.sh
+++ b/openshift-hack/build-go.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+set -eu
+
+
+REPO=github.com/openshift/cloud-provider-azure
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+WHAT=${1:-cloud-controller-manager}
+GLDFLAGS=${GLDFLAGS:-}
+
+eval $(go env | grep -e "GOHOSTOS" -e "GOHOSTARCH")
+
+: "${GOOS:=${GOHOSTOS}}"
+: "${GOARCH:=${GOHOSTARCH}}"
+
+
+cd "$REPO_ROOT"
+if [ -z ${VERSION_OVERRIDE+a} ]; then
+	echo "Using version from git..."
+	VERSION_OVERRIDE=$(git describe --abbrev=8 --dirty --always)
+fi
+
+VERSION_PKG=sigs.k8s.io/cloud-provider-azure/pkg/version
+
+GLDFLAGS="-extldflags '-static'"
+GLDFLAGS="$GLDFLAGS -X $VERSION_PKG.gitVersion=${REPO}"
+GLDFLAGS="$GLDFLAGS -X $VERSION_PKG.gitCommit=${VERSION_OVERRIDE}"
+GLDFLAGS="$GLDFLAGS -X $VERSION_PKG.buildDate=$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+
+eval $(go env)
+
+echo "Building ${REPO}/cmd/${WHAT} (${VERSION_OVERRIDE})"
+GO111MODULE=${GO111MODULE} CGO_ENABLED=0 GOOS=${GOOS} GOARCH=${GOARCH} go build ${GOFLAGS} -ldflags "${GLDFLAGS}" -o bin/${WHAT} ${REPO_ROOT}/cmd/${WHAT}

--- a/openshift-hack/images/cloud-controller-manager-openshift.Dockerfile
+++ b/openshift-hack/images/cloud-controller-manager-openshift.Dockerfile
@@ -1,0 +1,12 @@
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.16-openshift-4.8 AS builder
+WORKDIR /go/src/github.com/openshift/cloud-provider-azure
+COPY . .
+
+RUN make azure-cloud-controller-manager
+
+FROM registry.ci.openshift.org/ocp/4.8:base
+COPY --from=builder /go/src/github.com/openshift/cloud-provider-azure/bin/cloud-controller-manager /bin/azure-cloud-controller-manager
+
+LABEL description="Azure Cloud Controller Manager"
+
+ENTRYPOINT ["/bin/azure-cloud-controller-manager"]

--- a/openshift-hack/images/cloud-node-manager-openshift.Dockerfile
+++ b/openshift-hack/images/cloud-node-manager-openshift.Dockerfile
@@ -1,0 +1,12 @@
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.16-openshift-4.8 AS builder
+WORKDIR /go/src/github.com/openshift/cloud-provider-azure
+COPY . .
+
+RUN make azure-cloud-node-manager
+
+FROM registry.ci.openshift.org/ocp/4.8:base
+COPY --from=builder /go/src/github.com/openshift/cloud-provider-azure/bin/cloud-node-manager /bin/azure-cloud-node-manager
+
+LABEL description="Azure Cloud Node Manager"
+
+ENTRYPOINT ["/bin/azure-cloud-node-manager"]

--- a/openshift-hack/test-unit-ci.sh
+++ b/openshift-hack/test-unit-ci.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+DIR_LIST=$(go list ./... | grep -v tests/e2e)
+for DIR in $DIR_LIST
+do
+  go test -v "$DIR"
+done

--- a/openshift-hack/verify-history.sh
+++ b/openshift-hack/verify-history.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Verifies git commits starting from predefined prefix.
+
+# default to checking most recent commit only if not run by CI pipeline
+check_base="${PULL_BASE_SHA:-HEAD^}"
+check_sha="${PULL_PULL_SHA:-HEAD}"
+
+read -d '' help_message << EOF
+commit messages should look like one of:
+UPSTREAM: <carry>: message  (commits that should be carried indefinitely)
+UPSTREAM: <drop>: message   (commits that should be dropped on the next upstream rebase)
+UPSTREAM: 1234: message     (commits that should be carried until an upstream rebase includes upstream PR 1234)
+EOF
+
+prefix='UPSTREAM: ([0-9]+|<(carry|drop)>): '
+
+echo "examining commits between $check_base and $check_sha"
+echo
+
+while read -r message; do
+  if ! [[ "$message" =~ ^$prefix ]]; then
+    echo "Git history in this PR doesn't conform to set commit message standards. Offending commit message is:"
+    echo "$message"
+    echo
+    echo "$help_message"
+    exit 1
+  fi
+  echo "$message"
+done < <(git log "$check_base".."$check_sha" --pretty=%s --no-merges)
+
+echo
+echo "All looks good"

--- a/openshift.mk
+++ b/openshift.mk
@@ -1,0 +1,26 @@
+## --------------------------------------
+## Openshift specific make targets,
+## intended to be included in root Makefile in this repository
+## --------------------------------------
+
+azure-cloud-controller-manager:
+	openshift-hack/build-go.sh cloud-controller-manager
+.PHONY: azure-cloud-controller-manager
+
+azure-cloud-node-manager:
+	openshift-hack/build-go.sh cloud-node-manager
+.PHONY: azure-cloud-node-manager
+
+binaries: azure-cloud-controller-manager azure-cloud-node-manager
+.PHONY: binaries
+
+verify-history:
+	openshift-hack/verify-history.sh
+.PHONY: verify-history
+
+verify: test-lint test-gofmt test-govet
+.PHONY: verify
+
+test-unit-ci:
+	openshift-hack/test-unit-ci.sh
+.PHONY: test-unit-ci


### PR DESCRIPTION
Added so far
- ocp specific dockerfiles
- makefile with ocp specific targets
- openshift-hack directory for storing hack scripts and dockerfiles


Should be merged before https://github.com/openshift/release/pull/18569
