### PR TITLE
UPSTREAM: <carry>: set GOARCH appropriately

### DIFF
--- a/openshift-hack/images/cloud-controller-manager-openshift.Dockerfile
+++ b/openshift-hack/images/cloud-controller-manager-openshift.Dockerfile
@@ -2,7 +2,7 @@ FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.17-openshift-4.10 AS 
 WORKDIR /go/src/github.com/openshift/cloud-provider-azure
 COPY . .
 
-RUN make azure-cloud-controller-manager
+RUN make azure-cloud-controller-manager ARCH=$(go env GOARCH)
 
 FROM registry.ci.openshift.org/ocp/4.10:base
 COPY --from=builder /go/src/github.com/openshift/cloud-provider-azure/bin/cloud-controller-manager /bin/azure-cloud-controller-manager

--- a/openshift-hack/images/cloud-node-manager-openshift.Dockerfile
+++ b/openshift-hack/images/cloud-node-manager-openshift.Dockerfile
@@ -2,7 +2,7 @@ FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.17-openshift-4.10 AS 
 WORKDIR /go/src/github.com/openshift/cloud-provider-azure
 COPY . .
 
-RUN make azure-cloud-node-manager
+RUN make azure-cloud-node-manager ARCH=$(go env GOARCH)
 
 FROM registry.ci.openshift.org/ocp/4.10:base
 COPY --from=builder /go/src/github.com/openshift/cloud-provider-azure/bin/cloud-node-manager /bin/azure-cloud-node-manager


### PR DESCRIPTION
The Makefile sets GOARCH?=amd64, which needs to be overridden for this image to build properly on other architectures.
