### PR TITLE
Replace .dockerignore file with the OCP specific one

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,14 +1,12 @@
-*
-!.git
-!cloud-controller-manager
-!Makefile
-!openshift.mk
-!openshift-hack
-!hack
-!vendor
-!cmd
-!pkg
-!bin
-!go.mod
-!go.sum
-!tests
+# Exclude files and directories which are not needed for the OCP-specific image build process
+docs/
+examples/
+site/
+helm/
+
+/cloudbuild.yaml
+/netlify.toml
+
+# Ignore non openshift-specific dockerfiles at the project root
+/Dockerfile*
+/*.Dockerfile


### PR DESCRIPTION
Due to changes in OCP build process, original .dockerignore file started to cause issues.

This PR proposes to get rid of "ignore everything and allow specific files" strategy, and ignores things which is not needed or potentially interfere with the OCP build process.