### PR TITLE
fix .dockerignore to satisfy OCP specific requirements

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,7 +6,3 @@ helm/
 
 /cloudbuild.yaml
 /netlify.toml
-
-# Ignore non openshift-specific dockerfiles at the project root
-/Dockerfile*
-/*.Dockerfile


### PR DESCRIPTION
Apparently, OSBS relies on adding specific Dockerfile during an image build. Having `Dockerfile*` pattern in `.dockerignore` cause issues.