### PR TITLE
[4.11] bug OCPBUGS-2003: .dockerignore: enable OSBS2 builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,14 +1,8 @@
-*
-!.git
-!cloud-controller-manager
-!Makefile
-!openshift.mk
-!openshift-hack
-!hack
-!vendor
-!cmd
-!pkg
-!bin
-!go.mod
-!go.sum
-!tests
+# Exclude files and directories which are not needed for the OCP-specific image build process
+docs/
+examples/
+site/
+helm/
+
+/cloudbuild.yaml
+/netlify.toml


### PR DESCRIPTION
This is a backport of https://github.com/openshift/cloud-provider-azure/pull/36 and https://github.com/openshift/cloud-provider-azure/pull/37 which merged on master to enable building in OSBS2.
This will need to be backported as far as it is relevant because in the near future _everything_ will use OSBS2.
