### PR TITLE
OCPBUGS-8474: CCM should not panic when losing leader election lease

### DIFF
--- a/cmd/cloud-controller-manager/app/controllermanager.go
+++ b/cmd/cloud-controller-manager/app/controllermanager.go
@@ -134,7 +134,8 @@ func NewCloudControllerManagerCommand() *cobra.Command {
 					Callbacks: leaderelection.LeaderCallbacks{
 						OnStartedLeading: RunWrapper(s, c, healthHandler),
 						OnStoppedLeading: func() {
-							panic("leaderelection lost")
+							klog.ErrorS(nil, "leaderelection lost")
+							klog.FlushAndExit(klog.ExitFlushTimeout, 1)
 						},
 					},
 					WatchDog: electionChecker,


### PR DESCRIPTION
We have noticed in [CI](https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/release-openshift-origin-installer-launch-azure-modern/1632791244243472384) that the CCM will sometimes lose connection to the API server long enough to lose its leader election lease. Currently, this causes the code to panic which triggers the `undiagnosed panic in pod` error in CI.

Other CCMs use the core cloud-provider app which exits using klog (as per this PR) in a more graceful way (os.Exit), avoiding the need to use a panic.