### PR TITLE
RFE-4144: Increase service idle max timeout to 100 minutes

### DIFF
--- a/pkg/provider/azure_loadbalancer.go
+++ b/pkg/provider/azure_loadbalancer.go
@@ -2421,7 +2421,7 @@ func (az *Cloud) getExpectedLoadBalancingRulePropertiesForPort(
 	if lbIdleTimeout, err = consts.Getint32ValueFromK8sSvcAnnotation(service.Annotations, consts.ServiceAnnotationLoadBalancerIdleTimeout, func(val *int32) error {
 		const (
 			min = 4
-			max = 30
+			max = 100
 		)
 		if *val < min || *val > max {
 			return fmt.Errorf("idle timeout value must be a whole number representing minutes between %d and %d, actual value: %d", min, max, *val)


### PR DESCRIPTION
The value was changed by Azure to support a maximum of 100 minutes instead of 30 minutes. This PR bumps the allowed maximum in the code to prevent errors when trying to configure a valid maximum value.