### PR TITLE
OCPBUGS-29012: Remove concurrent-service-syncs limitation

### DIFF
--- a/cmd/cloud-controller-manager/app/options/options.go
+++ b/cmd/cloud-controller-manager/app/options/options.go
@@ -248,10 +248,6 @@ func (o *CloudControllerManagerOptions) Validate(allControllers, disabledByDefau
 		errors = append(errors, fmt.Errorf("--cloud-provider cannot be empty"))
 	}
 
-	if o.ServiceController.ConcurrentServiceSyncs != 1 {
-		errors = append(errors, fmt.Errorf("--concurrent-service-syncs is limited to 1 only"))
-	}
-
 	if !o.DynamicReloading.EnableDynamicReloading && o.KubeCloudShared.CloudProvider.CloudConfigFile == "" {
 		errors = append(errors, fmt.Errorf("--cloud-config cannot be empty when --enable-dynamic-reloading is not set to true"))
 	}

--- a/cmd/cloud-controller-manager/app/options/options_test.go
+++ b/cmd/cloud-controller-manager/app/options/options_test.go
@@ -317,8 +317,8 @@ func TestValidate(t *testing.T) {
 			},
 		},
 		{
-			desc:     "should return an error when validating options with concurrent service syncs not equal to 1",
-			expected: "--concurrent-service-syncs is limited to 1 only",
+			desc:     "should not return an error when validating options with concurrent service syncs not equal to 1",
+			expected: "",
 			generateTestCloudControllerManagerOptions: func() *CloudControllerManagerOptions {
 				s, _ := NewCloudControllerManagerOptions()
 				s.ServiceController.ConcurrentServiceSyncs = 10


### PR DESCRIPTION
This limitation was added upstream to prevent concurrent calls to `CreateOrUpdateLoadBalancer`. It was added 5 years ago and I would like to see if I can reproduce the issue with the current codebase.