### PR TITLE
OCPBUGS-26124,OCPBUGS-27861: update snyk file

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -5,3 +5,7 @@ exclude:
   global:
     - "vendor/**"
     - "**/vendor/**"
+    - "examples/**"
+    - "tests/**"
+    - "helm/**"
+    - "health-probe-proxy/example.yaml"


### PR DESCRIPTION
This change is reacting to a recent sast scan, it ensures that we are skipping files which are not included in our builds and releases.