### PR TITLE
OCPBUGS-28244: Call azureStackOverrides when parsing environment from env vars

### DIFF
--- a/pkg/provider/config/azure_auth.go
+++ b/pkg/provider/config/azure_auth.go
@@ -256,6 +256,9 @@ func ParseAzureEnvironment(cloudName, resourceManagerEndpoint, identitySystem st
 	} else {
 		klog.V(4).Infof("Using %s environment", cloudName)
 		env, err = azure.EnvironmentFromName(cloudName)
+		if err == nil {
+			azureStackOverrides(&env, env.ResourceManagerEndpoint, identitySystem)
+		}
 	}
 	return &env, err
 }

--- a/pkg/provider/config/azure_auth_test.go
+++ b/pkg/provider/config/azure_auth_test.go
@@ -392,6 +392,9 @@ func TestGetNetworkResourceServicePrincipalTokenNegative(t *testing.T) {
 }
 
 func TestParseAzureEnvironment(t *testing.T) {
+	modifiedChinaCloud := azure.ChinaCloud
+	modifiedChinaCloud.ManagementPortalURL = "https://portal.chinacloudapi.cn/"
+	modifiedChinaCloud.ServiceManagementEndpoint = "https://management.chinacloudapi.cn/"
 	cases := []struct {
 		cloudName               string
 		resourceManagerEndpoint string
@@ -408,7 +411,7 @@ func TestParseAzureEnvironment(t *testing.T) {
 			cloudName:               "AZURECHINACLOUD",
 			resourceManagerEndpoint: "",
 			identitySystem:          "",
-			expected:                &azure.ChinaCloud,
+			expected:                &modifiedChinaCloud,
 		},
 	}
 


### PR DESCRIPTION
This change calls azureStackOverrides on the env if we build from
environment.conf, rather than using the resourceManagerEndpoint.

We want to remove this once https://github.com/kubernetes-sigs/cloud-provider-azure/issues/5558 is resolved. 