### PR TITLE
[release-4.15] OCPBUGS-30970: Update acr-credential-provider.spec

### DIFF
--- a/acr-credential-provider.spec
+++ b/acr-credential-provider.spec
@@ -44,7 +44,7 @@
 # Customize from here.
 #
 
-%global golang_version 1.21.0
+%global golang_version 1.20.0
 %{!?version: %global version 0.0.1}
 %{!?release: %global release 1}
 %global package_name acr-credential-provider


### PR DESCRIPTION
Change go version to 1.20, rather than 1.21