### PR TITLE
OCPBUGS-50969: UPSTREAM: 8504: Fix GovCloud Config

### DIFF
--- a/pkg/provider/azure.go
+++ b/pkg/provider/azure.go
@@ -324,7 +324,7 @@ func (az *Cloud) InitializeCloudFromConfig(ctx context.Context, config *config.C
 		config.ClusterServiceSharedLoadBalancerHealthProbePath = consts.ClusterServiceLoadBalancerHealthProbeDefaultPath
 	}
 
-	clientOps, env, err := azclient.GetAzCoreClientOption(&az.ARMClientConfig)
+	clientOps, env, err := azclient.GetAzCoreClientOption(&config.ARMClientConfig)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This change uses the parsed `config` currently being reconciled to initialise the controller.