### PR TITLE
OCPBUGS-51090: Fix panic for GetZoneByNodeName on Azure Stack

### DIFF
--- a/pkg/provider/azure_standard.go
+++ b/pkg/provider/azure_standard.go
@@ -580,7 +580,11 @@ func (as *availabilitySet) GetZoneByNodeName(ctx context.Context, name string) (
 		failureDomain = as.makeZone(ptr.Deref(vm.Location, ""), zoneID)
 	} else {
 		// Availability zone is not used for the node, falling back to fault domain.
-		failureDomain = strconv.Itoa(int(ptr.Deref(vm.Properties.InstanceView.PlatformFaultDomain, 0)))
+		if prop := vm.Properties; prop == nil || prop.InstanceView == nil {
+			failureDomain = "0"
+		} else {
+			failureDomain = strconv.Itoa(int(ptr.Deref(vm.Properties.InstanceView.PlatformFaultDomain, 0)))
+		}
 	}
 
 	zone := cloudprovider.Zone{


### PR DESCRIPTION
Azure Stack does not support the API Version, 2020-12-01, for PlatformFaultDomain, and therefore panics when we run the cloud provider on Azure Stack. This avoids the panic, but we cannot get the correct PlatformFaultDomain (which may not be an issue).