### PR TITLE
UPSTREAM: 9196: Updates linter version and args in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -359,7 +359,7 @@ test-check: test-boilerplate test-helm ## Run all static checks.
 
 .PHONY: lint
 lint: golangci-lint ## Run golangci-lint against code.
-	$(LINTER) run -v -E exportloopref
+	$(LINTER) run -v
 
 .PHONY: test-boilerplate
 test-boilerplate: ## Run boilerplate test.
@@ -451,7 +451,7 @@ delete-workload-cluster:
 ##@ Tools
 
 LINTER = $(shell pwd)/bin/golangci-lint
-LINTER_VERSION = v1.60.1
+LINTER_VERSION = v1.64.8
 .PHONY: golangci-lint
 golangci-lint:  ## Download golangci-lint locally if necessary.
 	@echo "Installing golangci-lint"


### PR DESCRIPTION
In combination with the changes in the latest[ 1.33 rebase PR](https://github.com/openshift/cloud-provider-azure/pull/143) this will fix linting issues. 

Description of upstream commit: 

This change:

- Updates the linter version defined in the Makefile to match what is being run on github actions (1.60.1 -> 1.64.8).

This means the linter is compiled with go 1.24, rather than 1.23, fixing typing issues.

- Removes the flag enabling exportloopref, which is deprecated as of go 1.22