### PR TITLE
OCPSTRAT-1672: Update to use the user specified armEndpoint

### DIFF
--- a/pkg/azclient/cloud.go
+++ b/pkg/azclient/cloud.go
@@ -35,6 +35,48 @@ const (
 	EnvironmentFilepathName = "AZURE_ENVIRONMENT_FILEPATH"
 )
 
+// metadataEndpoint represents the structure of the metadata endpoint response
+type metadataEndpoint struct {
+	Name            string `json:"name"`
+	ResourceManager string `json:"resourceManager,omitempty"`
+	Authentication  struct {
+		Audiences     []string `json:"audiences"`
+		LoginEndpoint string   `json:"loginEndpoint,omitempty"`
+	} `json:"authentication"`
+	Suffixes struct {
+		AcrLoginServer *string `json:"acrLoginServer,omitempty"`
+		Storage        *string `json:"storage,omitempty"`
+	} `json:"suffixes,omitempty"`
+}
+
+// applyMetadataToConfig applies metadata endpoint configuration to cloud config and environment
+func applyMetadataToConfig(item metadataEndpoint, endpoint string, cloudConfig *cloud.Configuration, env *Environment) {
+	// We use the endpoint to build our config, but on ASH the config returned
+	// does not contain the endpoint, and this is not accounted for. This
+	// ultimately unsets it for the returned config, causing the bootstrap of
+	// the provider to fail. Instead, check if the endpoint is returned, and if
+	// It is not then set it.
+	if item.ResourceManager == "" {
+		item.ResourceManager = endpoint
+	}
+	cloudConfig.Services[cloud.ResourceManager] = cloud.ServiceConfiguration{
+		Endpoint: item.ResourceManager,
+		Audience: item.Authentication.Audiences[0],
+	}
+	env.ResourceManagerEndpoint = item.ResourceManager
+	env.TokenAudience = item.Authentication.Audiences[0]
+	if item.Authentication.LoginEndpoint != "" {
+		cloudConfig.ActiveDirectoryAuthorityHost = item.Authentication.LoginEndpoint
+		env.ActiveDirectoryEndpoint = item.Authentication.LoginEndpoint
+	}
+	if item.Suffixes.Storage != nil {
+		env.StorageEndpointSuffix = *item.Suffixes.Storage
+	}
+	if item.Suffixes.AcrLoginServer != nil {
+		env.ContainerRegistryDNSSuffix = *item.Suffixes.AcrLoginServer
+	}
+}
+
 // OverrideAzureCloudConfigAndEnvConfigFromMetadataService returns cloud config and environment config from url
 // track2 sdk will add this one in the near future https://github.com/Azure/azure-sdk-for-go/issues/20959
 // cloud and env should not be empty
@@ -54,18 +96,7 @@ func OverrideAzureCloudConfigAndEnvConfigFromMetadataService(endpoint, cloudName
 	if err != nil {
 		return err
 	}
-	metadata := []struct {
-		Name            string `json:"name"`
-		ResourceManager string `json:"resourceManager,omitempty"`
-		Authentication  struct {
-			Audiences     []string `json:"audiences"`
-			LoginEndpoint string   `json:"loginEndpoint,omitempty"`
-		} `json:"authentication"`
-		Suffixes struct {
-			AcrLoginServer *string `json:"acrLoginServer,omitempty"`
-			Storage        *string `json:"storage,omitempty"`
-		} `json:"suffixes,omitempty"`
-	}{}
+	var metadata []metadataEndpoint
 	err = json.Unmarshal(body, &metadata)
 	if err != nil {
 		return err
@@ -73,33 +104,17 @@ func OverrideAzureCloudConfigAndEnvConfigFromMetadataService(endpoint, cloudName
 
 	for _, item := range metadata {
 		if cloudName == "" || strings.EqualFold(item.Name, cloudName) {
-			// We use the endpoint to build our config, but on ASH the config returned
-			// does not contain the endpoint, and this is not accounted for. This
-			// ultimately unsets it for the returned config, causing the bootstrap of
-			// the provider to fail. Instead, check if the endpoint is returned, and if
-			// It is not then set it.
-			if item.ResourceManager == "" {
-				item.ResourceManager = endpoint
-			}
-			cloudConfig.Services[cloud.ResourceManager] = cloud.ServiceConfiguration{
-				Endpoint: item.ResourceManager,
-				Audience: item.Authentication.Audiences[0],
-			}
-			env.ResourceManagerEndpoint = item.ResourceManager
-			env.TokenAudience = item.Authentication.Audiences[0]
-			if item.Authentication.LoginEndpoint != "" {
-				cloudConfig.ActiveDirectoryAuthorityHost = item.Authentication.LoginEndpoint
-				env.ActiveDirectoryEndpoint = item.Authentication.LoginEndpoint
-			}
-			if item.Suffixes.Storage != nil {
-				env.StorageEndpointSuffix = *item.Suffixes.Storage
-			}
-			if item.Suffixes.AcrLoginServer != nil {
-				env.ContainerRegistryDNSSuffix = *item.Suffixes.AcrLoginServer
-			}
+			applyMetadataToConfig(item, endpoint, cloudConfig, env)
 			return nil
 		}
 	}
+
+	// Always return the first metadata if no name match and metadata is not empty
+	if len(metadata) > 0 {
+		applyMetadataToConfig(metadata[0], endpoint, cloudConfig, env)
+		return nil
+	}
+
 	return nil
 }
 

--- a/pkg/azclient/cloud_test.go
+++ b/pkg/azclient/cloud_test.go
@@ -148,6 +148,66 @@ var _ = ginkgo.Describe("Cloud", func() {
 				gomega.Expect(env.ResourceManagerEndpoint).To(gomega.Equal(server.URL))
 			})
 		})
+
+		ginkgo.When("the cloudName does not match any metadata", func() {
+			ginkgo.It("should use the first metadata entry as fallback", func() {
+				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+					w.WriteHeader(http.StatusOK)
+					_, err := w.Write([]byte(`
+[
+    {
+        "portal":"https://portal.azure.com",
+        "authentication":{
+            "loginEndpoint":"https://login.microsoftonline.com/",
+            "audiences":[
+                "https://management.core.windows.net/",
+                "https://management.azure.com/"
+            ],
+            "tenant":"common",
+            "identityProvider":"AAD"
+        },
+        "media":"https://rest.media.azure.net",
+        "graphAudience":"https://graph.windows.net/",
+        "graph":"https://graph.windows.net/",
+        "name":"AzureCloud",
+        "suffixes":{
+            "azureDataLakeStoreFileSystem":"azuredatalakestore.net",
+            "acrLoginServer":"azurecr.io",
+            "sqlServerHostname":"database.windows.net",
+            "azureDataLakeAnalyticsCatalogAndJob":"azuredatalakeanalytics.net",
+            "keyVaultDns":"vault.azure.net",
+            "storage":"core.windows.net",
+            "azureFrontDoorEndpointSuffix":"azurefd.net"
+        },
+        "batch":"https://batch.core.windows.net/",
+        "resourceManager":"https://management.azure.com/",
+        "vmImageAliasDoc":"https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/arm-compute/quickstart-templates/aliases.json",
+        "activeDirectoryDataLake":"https://datalake.azure.net/",
+        "sqlManagement":"https://management.core.windows.net:8443/",
+        "gallery":"https://gallery.azure.com/"
+    }
+]
+					`))
+					gomega.Expect(err).ToNot(gomega.HaveOccurred())
+				}))
+				defer server.Close()
+				cloudConfig := cloud.AzurePublic
+				env := &azclient.Environment{}
+				// Use a cloudName that doesn't match "AzureCloud"
+				err := azclient.OverrideAzureCloudConfigAndEnvConfigFromMetadataService(server.URL, "NonMatchingCloudName", &cloudConfig, env)
+				gomega.Expect(err).ToNot(gomega.HaveOccurred())
+				gomega.Expect(cloudConfig).ToNot(gomega.BeNil())
+				// Should still get the first metadata entry's values
+				gomega.Expect(cloudConfig.ActiveDirectoryAuthorityHost).To(gomega.Equal("https://login.microsoftonline.com/"))
+				gomega.Expect(cloudConfig.Services).NotTo(gomega.BeEmpty())
+				gomega.Expect(cloudConfig.Services[cloud.ResourceManager].Audience).To(gomega.Equal("https://management.core.windows.net/"))
+				gomega.Expect(cloudConfig.Services[cloud.ResourceManager].Endpoint).To(gomega.Equal("https://management.azure.com/"))
+				gomega.Expect(env).ToNot(gomega.BeNil())
+				gomega.Expect(env.ResourceManagerEndpoint).To(gomega.Equal("https://management.azure.com/"))
+				gomega.Expect(env.ContainerRegistryDNSSuffix).To(gomega.Equal("azurecr.io"))
+				gomega.Expect(env.StorageEndpointSuffix).To(gomega.Equal("core.windows.net"))
+			})
+		})
 	})
 	ginkgo.Context("EnvironmentFromName", func() {
 		ginkgo.When("cloud name is empty", func() {


### PR DESCRIPTION
Update the azure cloud provider operator to always return the first metadata if no name match and metadata is not empty. The reason for this is that the region names of the 2 new Azure-IL6 regions, and the overall cloud name, are not in the list of allowed regions from the openshift installer. Currently a "stub" region name is used like USGovernmentCloud to allow the installer to progress. When this operator queries the armEndpoint it compares the name of the user specified "stub" cloud name, USGovernmentCloud in this case, to the name of the cloud returned by the armEndpoint. In this case they will NOT match which causes an error.

Updating the code such that, if the armEndpoint does return the URI list, use it and continue.

This PR is mostly formatting changes and only this section is new:
```
+
+   // Always return the first metadata if no name match and metadata is not empty
+   if len(metadata) > 0 {
+       applyMetadataToConfig(metadata[0], endpoint, cloudConfig, env)
+       return nil
+   }
+
```