### PR TITLE
UPSTREAM: <carry>: Fix nil pointer dereference in VirtualMachine methods

### DIFF
--- a/pkg/provider/azure_vmss.go
+++ b/pkg/provider/azure_vmss.go
@@ -1036,9 +1036,11 @@ func (ss *ScaleSet) EnsureHostInPool(_ *v1.Service, nodeName types.NodeName, bac
 		}
 
 		logger.Error(err, "failed to get vmss vm", "vmName", vmName)
-		if !errors.Is(err, ErrorNotVmssInstance) {
-			return "", "", "", nil, err
+		if errors.Is(err, ErrorNotVmssInstance) {
+			klog.Infof("EnsureHostInPool: skipping node %s because it is not a VMSS instance", vmName)
+			return "", "", "", nil, nil
 		}
+		return "", "", "", nil, err
 	}
 	statuses := vm.GetInstanceViewStatus()
 	vmPowerState := vmutil.GetVMPowerState(vm.Name, statuses)

--- a/pkg/provider/virtualmachine/virtualmachine.go
+++ b/pkg/provider/virtualmachine/virtualmachine.go
@@ -129,10 +129,16 @@ func FromVirtualMachineScaleSetVM(vm *compute.VirtualMachineScaleSetVM, opt Mana
 }
 
 func (vm *VirtualMachine) IsVirtualMachine() bool {
+	if vm == nil {
+		return false
+	}
 	return vm.Variant == VariantVirtualMachine
 }
 
 func (vm *VirtualMachine) IsVirtualMachineScaleSetVM() bool {
+	if vm == nil {
+		return false
+	}
 	return vm.Variant == VariantVirtualMachineScaleSetVM
 }
 

--- a/pkg/provider/virtualmachine/virtualmachine.go
+++ b/pkg/provider/virtualmachine/virtualmachine.go
@@ -143,7 +143,7 @@ func (vm *VirtualMachine) IsVirtualMachineScaleSetVM() bool {
 }
 
 func (vm *VirtualMachine) ManagedByVMSS() bool {
-	return vm.Manage == VMSS
+	return vm != nil && vm.Manage == VMSS
 }
 
 func (vm *VirtualMachine) AsVirtualMachine() *compute.VirtualMachine {

--- a/pkg/provider/virtualmachine/virtualmachine_test.go
+++ b/pkg/provider/virtualmachine/virtualmachine_test.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package virtualmachine
+
+import (
+	"testing"
+
+	"sigs.k8s.io/cloud-provider-azure/pkg/consts"
+)
+
+func TestNilVirtualMachine(t *testing.T) {
+	var vm *VirtualMachine
+
+	if vm.IsVirtualMachine() {
+		t.Error("nil VirtualMachine should return false for IsVirtualMachine()")
+	}
+	if vm.IsVirtualMachineScaleSetVM() {
+		t.Error("nil VirtualMachine should return false for IsVirtualMachineScaleSetVM()")
+	}
+	if vm.ManagedByVMSS() {
+		t.Error("nil VirtualMachine should return false for ManagedByVMSS()")
+	}
+	if vm.GetInstanceViewStatus() != nil {
+		t.Error("nil VirtualMachine should return nil for GetInstanceViewStatus()")
+	}
+	if vm.GetProvisioningState() != consts.ProvisioningStateUnknown {
+		t.Errorf("nil VirtualMachine should return %q for GetProvisioningState(), got %q", consts.ProvisioningStateUnknown, vm.GetProvisioningState())
+	}
+}


### PR DESCRIPTION
## Summary
- Fix panic in `EnsureHostInPool` when `getVmssVM` returns `ErrorNotVmssInstance`: the code fell through to `vm.GetInstanceViewStatus()` with `vm == nil`, causing a nil pointer dereference
- Add nil receiver guards to `IsVirtualMachine()`, `IsVirtualMachineScaleSetVM()`, and `ManagedByVMSS()` as defense in depth
- Add unit tests for nil receiver behavior

## Root Cause
In `EnsureHostInPool` (`azure_vmss.go:1038-1042`), when `getVmssVM` returned `ErrorNotVmssInstance`, the negated condition `!errors.Is(err, ErrorNotVmssInstance)` evaluated to `false`, so the function did **not** return — it fell through to `vm.GetInstanceViewStatus()` with `vm == nil`, panicking at `IsVirtualMachine()` on the nil receiver.

## Fix
- **Call site fix**: Changed `EnsureHostInPool` to skip the node (return nil error) when `ErrorNotVmssInstance` is encountered, matching the pattern already used in `GetInstanceIDByNodeName`
- **Defensive fix**: Added `vm != nil` guards to `IsVirtualMachine()`, `IsVirtualMachineScaleSetVM()`, and `ManagedByVMSS()` so a nil receiver returns `false` instead of panicking

## Test plan
- [x] Added `TestNilVirtualMachine` unit test covering all nil receiver methods
- [x] Existing `TestEnsureHostInPool` passes
- [x] Full `pkg/provider/...` test suite passes (no failures)

Fixes: https://issues.redhat.com/browse/OCPBUGS-62712

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience of virtual machine identification to avoid crashes when VM data is absent.
  * Refined handling of scale-set VM lookups to return empty results and log appropriately when a VM is not from a scale set, improving reliability.

* **Tests**
  * Added unit tests validating nil-instance behavior and provisioning-state handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->