### PR TITLE
OCPBUGS-87408, OCPBUGS-87500: Art consistency openshift 5.0 azure fix

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-9-release-golang-1.25-openshift-4.22
+  tag: rhel-9-release-golang-1.26-openshift-5.0

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -41,6 +41,13 @@ linters:
       - std-error-handling
     rules:
       - linters:
+          - gosec
+        path: ^(pkg/provider/azure_test|pkg/util/iputil/bits)\.go$
+        text: "G602: slice index out of range"
+      - linters:
+          - revive
+        text: "var-naming: avoid package names that conflict with Go standard library package names"
+      - linters:
           - revive
         path: tests/e2e
     paths:

--- a/Makefile
+++ b/Makefile
@@ -474,11 +474,11 @@ delete-workload-cluster: ## Delete a CAPZ workload cluster.
 ##@ Tools
 
 LINTER = $(shell pwd)/bin/golangci-lint
-LINTER_VERSION = v2.5.0
+LINTER_VERSION = v2.9.0
 .PHONY: golangci-lint
 golangci-lint:  ## Download golangci-lint locally if necessary.
 	@echo "Installing golangci-lint"
-	@test -s $(LINTER) || curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(shell pwd)/bin $(LINTER_VERSION)
+	@test -s $(LINTER) || GOFLAGS="" GOBIN=$(shell pwd)/bin go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(LINTER_VERSION)
 
 ## --------------------------------------
 ## Openshift specific include

--- a/openshift-hack/images/cloud-controller-manager-openshift.Dockerfile
+++ b/openshift-hack/images/cloud-controller-manager-openshift.Dockerfile
@@ -1,10 +1,10 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.22 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.26-openshift-5.0 AS builder
 WORKDIR /go/src/github.com/openshift/cloud-provider-azure
 COPY . .
 
 RUN make azure-cloud-controller-manager ARCH=$(go env GOARCH)
 
-FROM registry.ci.openshift.org/ocp/4.22:base-rhel9
+FROM registry.ci.openshift.org/ocp/5.0:base-rhel9
 COPY --from=builder /go/src/github.com/openshift/cloud-provider-azure/bin/cloud-controller-manager /bin/azure-cloud-controller-manager
 
 LABEL description="Azure Cloud Controller Manager"

--- a/openshift-hack/images/cloud-node-manager-openshift.Dockerfile
+++ b/openshift-hack/images/cloud-node-manager-openshift.Dockerfile
@@ -1,10 +1,10 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.22 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.26-openshift-5.0 AS builder
 WORKDIR /go/src/github.com/openshift/cloud-provider-azure
 COPY . .
 
 RUN make azure-cloud-node-manager ARCH=$(go env GOARCH)
 
-FROM registry.ci.openshift.org/ocp/4.22:base-rhel9
+FROM registry.ci.openshift.org/ocp/5.0:base-rhel9
 COPY --from=builder /go/src/github.com/openshift/cloud-provider-azure/bin/cloud-node-manager /bin/azure-cloud-node-manager
 
 LABEL description="Azure Cloud Node Manager"


### PR DESCRIPTION
Alternative to #188, #189.

Includes the changes OpenShift docker containers by ART and a fix for golangci-lint.

The change to golang 1.26 requires a golangci-lint compiled with golang 1.26. This updates golangci-lint to a version compiled with golang 1.26. It's a drop commit as the upstream has changed the strategy with respect to getting golangci-lint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI and build environments to newer platform release images.
  * Refreshed the locally installed linting tool version and changed its installation method.
  * Upgraded controller-related container build/runtime base images to the latest platform version.
* **Bug Fixes**
  * Adjusted static analysis exclusions for specific test/util files to prevent irrelevant lint findings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->