### PR TITLE
OCPBUGS-99012: Update Go to 1.26.4 for security fixes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/cloud-provider-azure
 
-go 1.25.0
+go 1.26.4
 
 godebug default=go1.25
 


### PR DESCRIPTION
Update Go version from 1.25.0 to 1.26.4 to address security vulnerabilities.

Fixes: https://issues.redhat.com/browse/OCPBUGS-99012

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application’s Go toolchain version to 1.26.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->