### PR TITLE
OCPBUGS-99012: Update Go to 1.26.4 for security fixes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module sigs.k8s.io/cloud-provider-azure
 
-go 1.25.0
+go 1.26.4
 
-godebug default=go1.25
+godebug default=go1.26
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.0


### PR DESCRIPTION
## Summary

Update Go version from 1.25.0 to 1.26.4 to address multiple security vulnerabilities.

**Note:** This PR is based on commit `d04449b95` which is slightly behind current `main` (`f2af9b435`). The base commit has `go 1.25.0`, while current main has `go 1.26.0`. This PR updates to `go 1.26.4` which includes all the same CVE fixes regardless of whether rebased. The PR will need a rebase before merge, but the change itself (updating Go to 1.26.4) is correct and complete.

## Security Fixes

This update addresses:
- **CVE-2026-42504**: MIME DoS vulnerability (quadratic complexity in `mime.WordDecoder.DecodeHeader`)
- **CVE-2026-42507**: Security issue in crypto/x509
- **CVE-2026-27145**: Security issue in net/textproto

Go 1.26.4 was released on June 2, 2026 with fixes to crypto/x509, mime, and net/textproto packages.

## Changes

- `go.mod`: Update `go` directive from 1.25.0 to 1.26.4
- `go.mod`: Update `godebug` directive from go1.25 to go1.26

## Testing

CI will verify:
- All existing tests pass with Go 1.26.4
- Build succeeds with new Go version
- No regressions introduced

JIRA: https://redhat.atlassian.net/browse/OCPBUGS-99012