### PR TITLE
OCPBUGS-99012: Update Go to 1.26.4 for security fixes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/cloud-provider-azure
 
-go 1.26.0
+go 1.26.4
 
 godebug default=go1.26
 


### PR DESCRIPTION
## Summary

Update Go version from 1.26.0 to 1.26.4 to address multiple security vulnerabilities.

## Security Fixes

This update addresses:
- **CVE-2026-42504** (CVSS 7.5 High/Important): Golang MIME DoS - Denial of Service via maliciously-crafted MIME header. Decoding a maliciously-crafted MIME header containing many invalid encoded-words can consume excessive CPU due to quadratic complexity in `mime.WordDecoder.DecodeHeader`.
- **CVE-2026-42507**: Security issue in crypto/x509
- **CVE-2026-27145**: Security issue in net/textproto

Go 1.26.4 was released on June 2, 2026 with fixes to crypto/x509, mime, and net/textproto packages.

## Changes

- `go.mod`: Update `go` directive from 1.26.0 to 1.26.4

## Testing

CI will verify:
- All existing tests pass with Go 1.26.4
- Build succeeds with new Go version
- No regressions introduced

## References

- JIRA: https://redhat.atlassian.net/browse/OCPBUGS-99012
- Go release: https://github.com/golang/go/issues?q=milestone%3AGo1.26.4
- CVE-2026-42504: https://www.cve.org/CVERecord?id=CVE-2026-42504

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the Go toolchain version to 1.26.4.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->